### PR TITLE
Add styling and icons to the bottom tab bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@apollo/react-hooks": "3.1.3",
+    "@expo/vector-icons": "10.0.6",
     "@react-native-community/masked-view": "0.1.5",
     "@react-navigation/bottom-tabs": "5.0.5",
     "@react-navigation/native": "5.0.4",
@@ -22,6 +23,7 @@
     "graphql": "14.6.0",
     "graphql-tag": "latest",
     "mem": ">=4.0.0",
+    "prop-types": "15.7.2",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
@@ -29,7 +31,6 @@
     "react-native-reanimated": "1.4.0",
     "react-native-safe-area-context": "0.6.0",
     "react-native-screens": "2.0.0-alpha.12",
-    "prop-types": "15.7.2",
     "react-native-web": "~0.11.7"
   },
   "devDependencies": {

--- a/src/navigation/AppRouter.jsx
+++ b/src/navigation/AppRouter.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
 import { MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
 
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
@@ -15,52 +14,6 @@ export const NavigationStackIds = {
   explore: 'Explore',
   notifications: 'Notifications',
   profile: 'Profile',
-};
-
-// Options to configure how the tabs look
-const focusedTabColor = 'lightcoral';
-const unfocusedTabColor = 'grey';
-const tabScreenOptions = {
-  feed: {
-    // eslint-disable-next-line react/prop-types
-    tabBarIcon: ({ focused }) => (
-      focused
-        ? <MaterialCommunityIcons name="home-outline" size={30} color={focusedTabColor} />
-        : <MaterialCommunityIcons name="home-outline" size={30} color={unfocusedTabColor} />
-    ),
-  },
-  explore: {
-    // eslint-disable-next-line react/prop-types
-    tabBarIcon: ({ focused }) => (
-      focused
-        ? <MaterialIcons name="search" size={30} color={focusedTabColor} />
-        : <MaterialIcons name="search" size={30} color={unfocusedTabColor} />
-    ),
-  },
-  notifications: {
-    // eslint-disable-next-line react/prop-types
-    tabBarIcon: ({ focused }) => (
-      focused
-        ? <MaterialIcons name="notifications-none" size={30} color={focusedTabColor} />
-        : <MaterialIcons name="notifications-none" size={30} color={unfocusedTabColor} />
-    ),
-  },
-  profile: {
-    // eslint-disable-next-line react/prop-types
-    tabBarIcon: ({ focused }) => (
-      focused
-        ? <MaterialCommunityIcons name="account-outline" size={30} color={focusedTabColor} />
-        : <MaterialCommunityIcons name="account-outline" size={30} color={unfocusedTabColor} />
-    ),
-  },
-};
-
-tabScreenOptions.propTypes = {
-  focused: PropTypes.bool.isRequired,
-};
-
-const tabBarOptions = {
-  showLabel: false, // hides text labels for navigation bar
 };
 
 // Names we will use for screens throughout the app. Add your new screen names
@@ -160,6 +113,48 @@ const createNavigationStacks = () => {
 
 // Create the tab navigator using react navigation
 const Tab = createBottomTabNavigator();
+
+// Options to configure how the tabs look
+const focusedTabColor = 'lightcoral';
+const unfocusedTabColor = 'grey';
+const tabScreenOptions = {
+  feed: {
+    // eslint-disable-next-line react/prop-types
+    tabBarIcon: ({ focused }) => (
+      focused
+        ? <MaterialCommunityIcons name="home-outline" size={30} color={focusedTabColor} />
+        : <MaterialCommunityIcons name="home-outline" size={30} color={unfocusedTabColor} />
+    ),
+  },
+  explore: {
+    // eslint-disable-next-line react/prop-types
+    tabBarIcon: ({ focused }) => (
+      focused
+        ? <MaterialIcons name="search" size={30} color={focusedTabColor} />
+        : <MaterialIcons name="search" size={30} color={unfocusedTabColor} />
+    ),
+  },
+  notifications: {
+    // eslint-disable-next-line react/prop-types
+    tabBarIcon: ({ focused }) => (
+      focused
+        ? <MaterialIcons name="notifications-none" size={30} color={focusedTabColor} />
+        : <MaterialIcons name="notifications-none" size={30} color={unfocusedTabColor} />
+    ),
+  },
+  profile: {
+    // eslint-disable-next-line react/prop-types
+    tabBarIcon: ({ focused }) => (
+      focused
+        ? <MaterialCommunityIcons name="account-outline" size={30} color={focusedTabColor} />
+        : <MaterialCommunityIcons name="account-outline" size={30} color={unfocusedTabColor} />
+    ),
+  },
+};
+
+const tabBarOptions = {
+  showLabel: false, // hides text labels for navigation bar
+};
 
 // Build the react component for the tab navigator
 export default function TabNavigator() {

--- a/src/navigation/AppRouter.jsx
+++ b/src/navigation/AppRouter.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { PropTypes } from 'prop-types';
+import { MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
 
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -16,19 +18,49 @@ export const NavigationStackIds = {
 };
 
 // Options to configure how the tabs look
+const focusedTabColor = 'lightcoral';
+const unfocusedTabColor = 'grey';
 const tabScreenOptions = {
   feed: {
-    tabBarLabel: 'FEED',
+    // eslint-disable-next-line react/prop-types
+    tabBarIcon: ({ focused }) => (
+      focused
+        ? <MaterialCommunityIcons name="home-outline" size={30} color={focusedTabColor} />
+        : <MaterialCommunityIcons name="home-outline" size={30} color={unfocusedTabColor} />
+    ),
   },
   explore: {
-    tabBarLabel: 'EXPLORE',
+    // eslint-disable-next-line react/prop-types
+    tabBarIcon: ({ focused }) => (
+      focused
+        ? <MaterialIcons name="search" size={30} color={focusedTabColor} />
+        : <MaterialIcons name="search" size={30} color={unfocusedTabColor} />
+    ),
   },
   notifications: {
-    tabBarLabel: 'NOTIFICATIONS',
+    // eslint-disable-next-line react/prop-types
+    tabBarIcon: ({ focused }) => (
+      focused
+        ? <MaterialIcons name="notifications-none" size={30} color={focusedTabColor} />
+        : <MaterialIcons name="notifications-none" size={30} color={unfocusedTabColor} />
+    ),
   },
   profile: {
-    tabBarLabel: 'PROFILE',
+    // eslint-disable-next-line react/prop-types
+    tabBarIcon: ({ focused }) => (
+      focused
+        ? <MaterialCommunityIcons name="account-outline" size={30} color={focusedTabColor} />
+        : <MaterialCommunityIcons name="account-outline" size={30} color={unfocusedTabColor} />
+    ),
   },
+};
+
+tabScreenOptions.propTypes = {
+  focused: PropTypes.bool.isRequired,
+};
+
+const tabBarOptions = {
+  showLabel: false, // hides text labels for navigation bar
 };
 
 // Names we will use for screens throughout the app. Add your new screen names
@@ -134,7 +166,9 @@ export default function TabNavigator() {
   const navigationStacks = createNavigationStacks();
 
   return (
-    <Tab.Navigator>
+    <Tab.Navigator
+      tabBarOptions={tabBarOptions}
+    >
       <Tab.Screen
         name={NavigationStackIds.feed}
         component={navigationStacks[NavigationStackIds.feed]}


### PR DESCRIPTION
Change the tab bar styling to icons. Color the active icon. Removed tab bar label text.

![tabbar](https://user-images.githubusercontent.com/9399151/74628731-4148c680-510b-11ea-89bc-0cd1e951e62f.gif)
